### PR TITLE
fix(routing-001): stop cross-session misrouting of Telegram→CLI input

### DIFF
--- a/rust-crates/ctm/src/daemon/callback_handlers.rs
+++ b/rust-crates/ctm/src/daemon/callback_handlers.rs
@@ -279,9 +279,8 @@ async fn handle_confirm_abort_callback(ctx: &HandlerContext, session_id: &str, c
                 })
                 .await
             };
-            let mut inj = ctx.injector.lock().await;
-            inj.set_target(&target, socket.as_deref());
-            let _ = inj.send_key("Ctrl-C");
+            let inj = ctx.injector.lock().await;
+            let _ = inj.send_key(&target, socket.as_deref(), "Ctrl-C");
         }
 
         // Clear attached session state for this thread
@@ -2023,16 +2022,31 @@ fn sanitize_freetext(s: &str) -> String {
 }
 
 /// Capture the live pane and parse the widget view (`None` if no widget / capture failed).
-fn capture_view(inj: &crate::injector::InputInjector) -> Option<WidgetView> {
-    let pane = inj.capture_pane()?;
-    parse_widget(&pane)
+/// ROUTING-001: the tmux pane a submit flow drives. Passed explicitly through the
+/// stateless injector helpers so the shared `InputInjector` never holds mutable
+/// per-session target state (which previously could be clobbered by a concurrent
+/// handler and misroute keystrokes to the wrong pane).
+#[derive(Clone, Copy)]
+struct Pane<'a> {
+    target: &'a str,
+    socket: Option<&'a str>,
+}
+
+fn capture_view(inj: &crate::injector::InputInjector, pane: Pane<'_>) -> Option<WidgetView> {
+    let text = inj.capture_pane(pane.target, pane.socket)?;
+    parse_widget(&text)
 }
 
 /// Send a whitelisted key; on tmux ack set `mutated` and pace for the Ink repaint.
 /// Returns false on any non-`Ok(true)` (fail closed). A Down/Up navigation key counts as
 /// a mutation (conservative): once any key is acknowledged, a later failure is "dirty".
-async fn press(inj: &crate::injector::InputInjector, key: &str, mutated: &mut bool) -> bool {
-    match inj.send_key(key) {
+async fn press(
+    inj: &crate::injector::InputInjector,
+    pane: Pane<'_>,
+    key: &str,
+    mutated: &mut bool,
+) -> bool {
+    match inj.send_key(pane.target, pane.socket, key) {
         Ok(true) => {
             *mutated = true;
             tokio::time::sleep(tokio::time::Duration::from_millis(KEY_DELAY_MS)).await;
@@ -2043,8 +2057,13 @@ async fn press(inj: &crate::injector::InputInjector, key: &str, mutated: &mut bo
 }
 
 /// Type literal free-text (no trailing Enter) into the focused `Type something` row.
-async fn type_text(inj: &crate::injector::InputInjector, text: &str, mutated: &mut bool) -> bool {
-    match inj.inject_literal(text) {
+async fn type_text(
+    inj: &crate::injector::InputInjector,
+    pane: Pane<'_>,
+    text: &str,
+    mutated: &mut bool,
+) -> bool {
+    match inj.inject_literal(pane.target, pane.socket, text) {
         Ok(true) => {
             *mutated = true;
             tokio::time::sleep(tokio::time::Duration::from_millis(KEY_DELAY_MS)).await;
@@ -2063,6 +2082,7 @@ async fn type_text(inj: &crate::injector::InputInjector, text: &str, mutated: &m
 /// fired (that was the old key-leak bug). `mutated` is set as soon as any Down is acked.
 async fn place_cursor_on(
     inj: &crate::injector::InputInjector,
+    pane: Pane<'_>,
     target: RowTarget,
     total_options: usize,
     mutated: &mut bool,
@@ -2070,7 +2090,7 @@ async fn place_cursor_on(
     let interval = tokio::time::Duration::from_millis(READY_POLL_INTERVAL_MS);
     let max_steps = total_options + NAV_SLACK_STEPS;
     for step in 0..=max_steps {
-        match capture_view(inj) {
+        match capture_view(inj, pane) {
             Some(view) => {
                 if view.cursor_row().is_some_and(|k| row_is(k, target)) {
                     return true;
@@ -2081,7 +2101,7 @@ async fn place_cursor_on(
         if step == max_steps {
             break;
         }
-        if !press(inj, "Down", mutated).await {
+        if !press(inj, pane, "Down", mutated).await {
             return false;
         }
         tokio::time::sleep(interval).await;
@@ -2090,10 +2110,10 @@ async fn place_cursor_on(
 }
 
 /// Wait until a question screen with at least one focusable row is rendered.
-async fn wait_for_widget(inj: &crate::injector::InputInjector) -> bool {
+async fn wait_for_widget(inj: &crate::injector::InputInjector, pane: Pane<'_>) -> bool {
     let interval = tokio::time::Duration::from_millis(READY_POLL_INTERVAL_MS);
     for _ in 0..WAIT_STATE_MAX_POLLS {
-        if capture_view(inj).is_some_and(|v| !v.rows.is_empty()) {
+        if capture_view(inj, pane).is_some_and(|v| !v.rows.is_empty()) {
             return true;
         }
         tokio::time::sleep(interval).await;
@@ -2105,10 +2125,14 @@ async fn wait_for_widget(inj: &crate::injector::InputInjector) -> bool {
 /// before the advancing keystroke) — i.e. the widget advanced to the next question. The
 /// signature excludes the volatile status line/clock, so only a real screen change trips
 /// it. Fail closed on timeout.
-async fn wait_for_transition(inj: &crate::injector::InputInjector, pre_sig: Option<&str>) -> bool {
+async fn wait_for_transition(
+    inj: &crate::injector::InputInjector,
+    pane: Pane<'_>,
+    pre_sig: Option<&str>,
+) -> bool {
     let interval = tokio::time::Duration::from_millis(READY_POLL_INTERVAL_MS);
     for _ in 0..WAIT_STATE_MAX_POLLS {
-        if let Some(v) = capture_view(inj) {
+        if let Some(v) = capture_view(inj, pane) {
             if !v.rows.is_empty() && Some(v.signature().as_str()) != pre_sig {
                 return true;
             }
@@ -2121,10 +2145,10 @@ async fn wait_for_transition(inj: &crate::injector::InputInjector, pre_sig: Opti
 /// Wait until the end-of-widget confirm screen is showing AND the cursor is on the
 /// `Submit answers` row (its default). Returns true only when both hold, so the caller's
 /// subsequent Enter can never be a blind press / land on `Cancel`. Fail closed on timeout.
-async fn wait_for_confirm(inj: &crate::injector::InputInjector) -> bool {
+async fn wait_for_confirm(inj: &crate::injector::InputInjector, pane: Pane<'_>) -> bool {
     let interval = tokio::time::Duration::from_millis(READY_POLL_INTERVAL_MS);
     for _ in 0..WAIT_STATE_MAX_POLLS {
-        if let Some(v) = capture_view(inj) {
+        if let Some(v) = capture_view(inj, pane) {
             if v.is_confirm && v.cursor_row() == Some(RowKind::ConfirmSubmit) {
                 return true;
             }
@@ -2153,15 +2177,18 @@ async fn inject_answers(
     socket: Option<&str>,
     answers: &[InjItem],
 ) -> InjectOutcome {
-    let mut inj = ctx.injector.lock().await;
-    inj.set_target(target, socket);
+    // ROUTING-001: hold the injector lock for the whole submit so this flow has
+    // exclusive use of tmux, and drive the stateless injector with an explicit
+    // `Pane` — no shared mutable target that a concurrent handler could clobber.
+    let inj = ctx.injector.lock().await;
+    let pane = Pane { target, socket };
 
     let n = answers.len();
     let any_multi = answers.iter().any(|it| it.multi_select);
     let mut mutated = false;
 
     // Ensure the widget is on screen before the first keystroke.
-    if !wait_for_widget(&inj).await {
+    if !wait_for_widget(&inj, pane).await {
         return fail_outcome(mutated);
     }
 
@@ -2174,34 +2201,35 @@ async fn inject_answers(
         // single-select; the Next/Submit advance row for multi-select).
         match &item.answer {
             CollectedAnswer::Single(idx) => {
-                if !place_cursor_on(&inj, RowTarget::Option(*idx), max, &mut mutated).await {
+                if !place_cursor_on(&inj, pane, RowTarget::Option(*idx), max, &mut mutated).await {
                     return fail_outcome(mutated);
                 }
             }
             CollectedAnswer::Multi(idxs) => {
                 for &idx in idxs {
-                    if !place_cursor_on(&inj, RowTarget::Option(idx), max, &mut mutated).await {
+                    if !place_cursor_on(&inj, pane, RowTarget::Option(idx), max, &mut mutated).await
+                    {
                         return fail_outcome(mutated);
                     }
-                    if !press(&inj, "Enter", &mut mutated).await {
+                    if !press(&inj, pane, "Enter", &mut mutated).await {
                         return fail_outcome(mutated); // toggle
                     }
                 }
-                if !place_cursor_on(&inj, RowTarget::Advance, max, &mut mutated).await {
+                if !place_cursor_on(&inj, pane, RowTarget::Advance, max, &mut mutated).await {
                     return fail_outcome(mutated);
                 }
             }
             CollectedAnswer::FreeText(text) => {
-                if !place_cursor_on(&inj, RowTarget::TypeSomething, max, &mut mutated).await {
+                if !place_cursor_on(&inj, pane, RowTarget::TypeSomething, max, &mut mutated).await {
                     return fail_outcome(mutated);
                 }
-                if !type_text(&inj, &sanitize_freetext(text), &mut mutated).await {
+                if !type_text(&inj, pane, &sanitize_freetext(text), &mut mutated).await {
                     return fail_outcome(mutated);
                 }
                 // Multi-select free-text does NOT auto-advance — navigate to the advance
                 // row. Single-select free-text commits+advances on the common Enter below.
                 if item.multi_select
-                    && !place_cursor_on(&inj, RowTarget::Advance, max, &mut mutated).await
+                    && !place_cursor_on(&inj, pane, RowTarget::Advance, max, &mut mutated).await
                 {
                     return fail_outcome(mutated);
                 }
@@ -2210,8 +2238,8 @@ async fn inject_answers(
 
         // The advancing Enter (selects+advances / commits+advances / activates Next/Submit).
         // Snapshot the signature first so we can verify the advance actually happened.
-        let pre_sig = capture_view(&inj).map(|v| v.signature());
-        if !press(&inj, "Enter", &mut mutated).await {
+        let pre_sig = capture_view(&inj, pane).map(|v| v.signature());
+        if !press(&inj, pane, "Enter", &mut mutated).await {
             return fail_outcome(mutated);
         }
 
@@ -2219,14 +2247,14 @@ async fn inject_answers(
             // End of widget. A confirm screen appears for any N≥2 (incl. all-single-select)
             // and for N=1 multi-select. N=1 single-select submits directly (no confirm).
             if n >= 2 || any_multi {
-                if !wait_for_confirm(&inj).await {
+                if !wait_for_confirm(&inj, pane).await {
                     return InjectOutcome::FailedDirty; // we pressed Enter → dirty
                 }
-                if !press(&inj, "Enter", &mut mutated).await {
+                if !press(&inj, pane, "Enter", &mut mutated).await {
                     return InjectOutcome::FailedDirty;
                 }
             }
-        } else if !wait_for_transition(&inj, pre_sig.as_deref()).await {
+        } else if !wait_for_transition(&inj, pane, pre_sig.as_deref()).await {
             return InjectOutcome::FailedDirty;
         }
     }

--- a/rust-crates/ctm/src/daemon/mod.rs
+++ b/rust-crates/ctm/src/daemon/mod.rs
@@ -342,28 +342,12 @@ impl Daemon {
             }
         }
 
-        // H9: Auto-detect tmux session at startup
-        {
-            let mut inj = self.state.injector.lock().await;
-            if let Some(info) = InputInjector::detect_tmux_session() {
-                inj.set_target(&info.target, info.socket.as_deref());
-                tracing::info!(
-                    target = %info.target,
-                    session = %info.session,
-                    "Input injector auto-detected tmux session at startup"
-                );
-            } else if let Some(session) = InputInjector::find_claude_code_session() {
-                inj.set_target(&session, None);
-                tracing::info!(
-                    target = %session,
-                    "Input injector found Claude Code tmux session at startup"
-                );
-            } else {
-                tracing::info!(
-                    "No tmux session detected at startup — will use per-session targets"
-                );
-            }
-        }
+        // ROUTING-001: The injector is stateless — it no longer carries a default
+        // tmux target. Per-session targets are resolved at injection time from the
+        // session row / cache (see `get_tmux_target`). A process-wide default was
+        // actively harmful: it biased every session toward whatever pane happened
+        // to be detected first (typically pane 0), which is exactly how a reply for
+        // one session leaked into another's pane. Nothing to seed here anymore.
 
         // ADR-013 F8: Warm session_tmux_targets cache from DB on startup.
         // After a daemon restart, the in-memory cache is empty. Populate it from
@@ -808,6 +792,33 @@ async fn check_and_update_tmux_target(ctx: &HandlerContext, msg: &BridgeMessage)
 
     let current = ctx.session_tmux.read().await.get(&msg.session_id).cloned();
     if current.as_deref() == Some(new_target) {
+        // ROUTING-001: target unchanged, but the SOCKET may still have changed
+        // (e.g. a new tmux server with the same `session:win.pane` string).
+        // Injection now reads the socket from the session row, so a stale `-S`
+        // would route to the wrong tmux server. Reconcile the socket without
+        // claiming a target "change" (return false → no reconnect notification).
+        let sid = msg.session_id.clone();
+        let stored_socket = ctx
+            .db_op(move |sess| {
+                sess.get_tmux_info(&sid)
+                    .ok()
+                    .flatten()
+                    .and_then(|(_t, s)| s)
+            })
+            .await;
+        if stored_socket.as_deref() != new_socket {
+            let sid = msg.session_id.clone();
+            let target = new_target.to_string();
+            let socket = new_socket.map(|s| s.to_string());
+            ctx.db_op(move |sess| {
+                let _ = sess.set_tmux_info(&sid, Some(&target), socket.as_deref());
+            })
+            .await;
+            tracing::info!(
+                session_id = %msg.session_id,
+                "ROUTING-001: tmux socket changed (target unchanged) — reconciled"
+            );
+        }
         return false;
     }
 
@@ -1262,57 +1273,27 @@ async fn get_tmux_target(
         return Some(target);
     }
 
-    // Tier 3: ADR-013 F6 — Live detection fallback (~100ms).
-    // Try detect_tmux_session first (uses $TMUX env), then find_claude_code_session
-    // (scans all tmux panes for a "claude" process).
-    if let Some(info) = InputInjector::detect_tmux_session() {
-        let target = info.target.clone();
-        let socket = info.socket.clone();
-        tracing::info!(
-            session_id,
-            target = %target,
-            "ADR-013 F6: Live tmux detection succeeded (detect_tmux_session)"
-        );
-        // Store in cache
-        ctx.session_tmux
-            .write()
-            .await
-            .insert(session_id.to_string(), target.clone());
-        // Store in DB
-        let sid = session_id.to_string();
-        let t = target.clone();
-        let s = socket.clone();
-        ctx.db_op(move |sess| {
-            let _ = sess.set_tmux_info(&sid, Some(&t), s.as_deref());
-        })
-        .await;
-        return Some(target);
-    }
-
-    if let Some(session_name) = InputInjector::find_claude_code_session() {
-        // find_claude_code_session returns just a session name, not a full target.
-        // Use "session_name:0.0" as the target (first window, first pane).
-        let target = format!("{session_name}:0.0");
-        tracing::info!(
-            session_id,
-            target = %target,
-            "ADR-013 F6: Live tmux detection succeeded (find_claude_code_session)"
-        );
-        // Store in cache
-        ctx.session_tmux
-            .write()
-            .await
-            .insert(session_id.to_string(), target.clone());
-        // Store in DB
-        let sid = session_id.to_string();
-        let t = target.clone();
-        ctx.db_op(move |sess| {
-            let _ = sess.set_tmux_info(&sid, Some(&t), None);
-        })
-        .await;
-        return Some(target);
-    }
-
+    // ROUTING-001 (H2 fix): NO live-detection fallback for per-session routing.
+    //
+    // The previous Tier 3 tried `detect_tmux_session()` (the *daemon's* own $TMUX
+    // pane) and then `find_claude_code_session()`, which scans for the FIRST tmux
+    // pane running a "claude" process and manufactures `"{session}:0.0"` — pane 0.
+    // It then PERSISTED that guess into this session's cache + DB. For a session
+    // whose pane mapping is genuinely missing, that silently and permanently bound
+    // its inbound Telegram input to pane 0 (some *other* session). This is precisely
+    // the reported failure: text typed in session-2's topic landing in pane 0.
+    //
+    // A guessed target is never safe: tmux pane indices are not stable identifiers
+    // and "first claude pane" has no relationship to the requesting session. Fail
+    // closed instead — the only tmux target we trust is the one the Claude hook
+    // reported for THIS session (recorded at session_start, see socket_handlers).
+    // Callers surface a clear "tmux not detected" message to the user, which is
+    // strictly better than misdelivering keystrokes to the wrong Claude session.
+    tracing::warn!(
+        session_id,
+        "ROUTING-001: no tmux target in cache or DB for this session — refusing to \
+         guess a pane (would risk misrouting to another session). Failing closed."
+    );
     None
 }
 

--- a/rust-crates/ctm/src/daemon/telegram_handlers.rs
+++ b/rust-crates/ctm/src/daemon/telegram_handlers.rs
@@ -85,38 +85,39 @@ async fn handle_telegram_text(ctx: &HandlerContext, msg: &TgMessage, text: &str)
         None => return,
     };
 
-    // Get tmux info
+    // Get tmux info. ROUTING-001: resolve the per-session pane target and socket
+    // into locals and pass them explicitly to every injector call below. The
+    // injector is stateless, so there is no shared `set_target` that a concurrent
+    // handler for another session could clobber between resolution and injection.
     let tmux_target = get_tmux_target(ctx, &session.id, session.tmux_socket.as_deref()).await;
-
-    if let Some(target) = &tmux_target {
-        let mut inj = ctx.injector.lock().await;
-        let socket = session.tmux_socket.as_deref();
-        inj.set_target(target, socket);
-    }
 
     // ADR-013 D1/D2: If no tmux target is available, warn the user immediately
     // on every attempt (D2: no suppression after first occurrence). Commands
     // that depend on tmux injection (cc, interrupt, kill, free-text injection)
     // all short-circuit here.
-    if tmux_target.is_none() {
-        // Check for pending AskUserQuestion free-text answer first — those
-        // are stored as tentative answers and don't require tmux injection yet.
-        if handle_free_text_answer(ctx, &session.id, text).await {
+    let target = match tmux_target.as_deref() {
+        Some(t) => t,
+        None => {
+            // Check for pending AskUserQuestion free-text answer first — those
+            // are stored as tentative answers and don't require tmux injection yet.
+            if handle_free_text_answer(ctx, &session.id, text).await {
+                return;
+            }
+            tracing::warn!(
+                session_id = %session.id,
+                "ADR-013 D1: tmux not detected, cannot inject Telegram reply"
+            );
+            ctx.bot
+                .send_message(
+                    "\u{26A0}\u{FE0F} Reply failed \u{2014} tmux not detected. Start Claude Code inside tmux for bidirectional chat.",
+                    None,
+                    Some(thread_id),
+                )
+                .await;
             return;
         }
-        tracing::warn!(
-            session_id = %session.id,
-            "ADR-013 D1: tmux not detected, cannot inject Telegram reply"
-        );
-        ctx.bot
-            .send_message(
-                "\u{26A0}\u{FE0F} Reply failed \u{2014} tmux not detected. Start Claude Code inside tmux for bidirectional chat.",
-                None,
-                Some(thread_id),
-            )
-            .await;
-        return;
-    }
+    };
+    let socket = session.tmux_socket.as_deref();
 
     // cc command prefix: "cc clear" -> "/clear"
     if text.to_lowercase().starts_with("cc ") {
@@ -124,14 +125,14 @@ async fn handle_telegram_text(ctx: &HandlerContext, msg: &TgMessage, text: &str)
         // Track for echo prevention
         add_echo_key(ctx, &session.id, &command).await;
         let inj = ctx.injector.lock().await;
-        let _ = inj.send_slash_command(&command);
+        let _ = inj.send_slash_command(target, socket, &command);
         return;
     }
 
     // BUG-004: Interrupt commands (Escape)
     if is_interrupt_command(text) {
         let inj = ctx.injector.lock().await;
-        let ok = inj.send_key("Escape").unwrap_or(false);
+        let ok = inj.send_key(target, socket, "Escape").unwrap_or(false);
         let msg_text = if ok {
             "\u{23F8}\u{FE0F} *Interrupt sent* (Escape)\n\n_Claude should pause the current operation._"
         } else {
@@ -153,7 +154,7 @@ async fn handle_telegram_text(ctx: &HandlerContext, msg: &TgMessage, text: &str)
     // BUG-004: Kill commands (Ctrl-C)
     if is_kill_command(text) {
         let inj = ctx.injector.lock().await;
-        let ok = inj.send_key("Ctrl-C").unwrap_or(false);
+        let ok = inj.send_key(target, socket, "Ctrl-C").unwrap_or(false);
         let msg_text = if ok {
             "\u{1F6D1} *Kill sent* (Ctrl-C)\n\n_Claude should exit entirely._"
         } else {
@@ -202,7 +203,7 @@ async fn handle_telegram_text(ctx: &HandlerContext, msg: &TgMessage, text: &str)
     // Inject into CLI via tmux
     let injected = {
         let inj = ctx.injector.lock().await;
-        inj.inject(&inject_text).unwrap_or(false)
+        inj.inject(target, socket, &inject_text).unwrap_or(false)
     };
 
     if !injected {
@@ -408,9 +409,10 @@ async fn inject_to_session(
     let tmux_target = get_tmux_target(ctx, &session.id, session.tmux_socket.as_deref()).await;
 
     if let Some(target) = tmux_target {
-        let mut inj = ctx.injector.lock().await;
-        inj.set_target(&target, session.tmux_socket.as_deref());
-        let ok = inj.inject(text).unwrap_or(false);
+        let inj = ctx.injector.lock().await;
+        let ok = inj
+            .inject(&target, session.tmux_socket.as_deref(), text)
+            .unwrap_or(false);
         if ok {
             ctx.bot
                 .send_message(&format!("{what} sent to Claude"), None, Some(thread_id))
@@ -614,10 +616,12 @@ async fn handle_bot_command(ctx: &HandlerContext, msg: &TgMessage, text: &str) {
                 let tmux_target =
                     get_tmux_target(ctx, &session.id, session.tmux_socket.as_deref()).await;
                 if let Some(target) = tmux_target {
-                    let mut inj = ctx.injector.lock().await;
-                    inj.set_target(&target, session.tmux_socket.as_deref());
+                    let inj = ctx.injector.lock().await;
                     let command = format!("/rename {args}");
-                    if inj.send_slash_command(&command).unwrap_or(false) {
+                    if inj
+                        .send_slash_command(&target, session.tmux_socket.as_deref(), &command)
+                        .unwrap_or(false)
+                    {
                         ctx.bot
                             .send_message(
                                 &format!("Sending rename to Claude Code: *{args}*"),
@@ -832,9 +836,8 @@ async fn handle_bot_command(ctx: &HandlerContext, msg: &TgMessage, text: &str) {
                                 })
                                 .await
                             };
-                            let mut inj = ctx.injector.lock().await;
-                            inj.set_target(&target, socket.as_deref());
-                            let _ = inj.send_key("Escape");
+                            let inj = ctx.injector.lock().await;
+                            let _ = inj.send_key(&target, socket.as_deref(), "Escape");
                         }
 
                         // Broadcast abort command to socket clients (matches TS behaviour)

--- a/rust-crates/ctm/src/injector.rs
+++ b/rust-crates/ctm/src/injector.rs
@@ -7,10 +7,17 @@ use std::process::Command;
 /// Security: ALL tmux commands use Command::arg() — NO shell interpolation.
 /// This prevents command injection via user-controlled inputs like session names,
 /// socket paths, or message text.
-pub struct InputInjector {
-    tmux_target: Option<String>,
-    tmux_socket: Option<String>,
-}
+///
+/// ROUTING-001 (stateless routing): this type holds **no** tmux target/socket
+/// state. Every action method takes the `(target, socket)` pair explicitly, so a
+/// single shared `InputInjector` (behind a `Mutex` whose only job is to serialize
+/// tmux command execution) can never bleed one session's pane onto another's
+/// injection. The previous design stored a mutable `tmux_target` that callers set
+/// in one critical section and read in another — a TOCTOU race that misrouted a
+/// reply meant for session B into session A's pane when handlers ran concurrently
+/// (each Telegram update is `tokio::spawn`-ed). Passing the target per call
+/// eliminates that class of bug entirely.
+pub struct InputInjector;
 
 impl Default for InputInjector {
     fn default() -> Self {
@@ -20,17 +27,15 @@ impl Default for InputInjector {
 
 impl InputInjector {
     pub fn new() -> Self {
-        Self {
-            tmux_target: None,
-            tmux_socket: None,
-        }
+        Self
     }
 
-    /// Set the tmux target and optional socket path.
-    /// Validates socket path to prevent directory traversal.
-    pub fn set_target(&mut self, target: &str, socket: Option<&str>) {
-        self.tmux_target = Some(target.to_string());
-        self.tmux_socket = socket.and_then(|s| {
+    /// Validate + sanitize a tmux socket path, rejecting traversal / non-absolute /
+    /// oversized paths. A rejected socket degrades to `None` (default tmux server),
+    /// matching the historical `set_target` behavior. Centralized here so every
+    /// stateless entry point applies the same guard.
+    fn sanitized_socket(socket: Option<&str>) -> Option<String> {
+        socket.and_then(|s| {
             if s.contains("..") {
                 tracing::warn!(path = %s, "Rejecting tmux socket path with '..' traversal");
                 return None;
@@ -44,26 +49,22 @@ impl InputInjector {
                 return None;
             }
             Some(s.to_string())
-        });
+        })
     }
 
-    /// Get the socket args for tmux commands
-    fn socket_args(&self) -> Vec<&str> {
-        match &self.tmux_socket {
+    /// Build the `-S <socket>` args for a tmux command from a sanitized socket.
+    fn socket_args(socket: &Option<String>) -> Vec<&str> {
+        match socket {
             Some(s) => vec!["-S", s.as_str()],
             None => vec![],
         }
     }
 
-    /// Validate that the tmux target pane exists (BUG-001 fix)
-    pub fn validate_target(&self) -> std::result::Result<(), String> {
-        let target = self
-            .tmux_target
-            .as_deref()
-            .ok_or_else(|| "No tmux session configured".to_string())?;
-
+    /// Validate that the tmux target pane exists (BUG-001 fix).
+    pub fn validate_target(target: &str, socket: Option<&str>) -> std::result::Result<(), String> {
+        let socket = Self::sanitized_socket(socket);
         let mut cmd = Command::new("tmux");
-        for arg in self.socket_args() {
+        for arg in Self::socket_args(&socket) {
             cmd.arg(arg);
         }
         cmd.arg("list-panes").arg("-t").arg(target);
@@ -78,22 +79,18 @@ impl InputInjector {
         }
     }
 
-    /// Inject text input into the tmux pane.
+    /// Inject text input into the given tmux pane (literal text + trailing Enter).
     /// Uses Command::arg() — no shell interpolation possible.
-    pub fn inject(&self, text: &str) -> Result<bool> {
-        let target = match &self.tmux_target {
-            Some(t) => t,
-            None => return Ok(false),
-        };
-
-        if let Err(reason) = self.validate_target() {
+    pub fn inject(&self, target: &str, socket: Option<&str>, text: &str) -> Result<bool> {
+        if let Err(reason) = Self::validate_target(target, socket) {
             tracing::warn!(%reason, "Target validation failed");
             return Ok(false);
         }
+        let socket = Self::sanitized_socket(socket);
 
         // Send text with -l (literal mode)
         let mut send_cmd = Command::new("tmux");
-        for arg in self.socket_args() {
+        for arg in Self::socket_args(&socket) {
             send_cmd.arg(arg);
         }
         send_cmd
@@ -114,7 +111,7 @@ impl InputInjector {
 
         // Send Enter key separately
         let mut enter_cmd = Command::new("tmux");
-        for arg in self.socket_args() {
+        for arg in Self::socket_args(&socket) {
             enter_cmd.arg(arg);
         }
         enter_cmd
@@ -148,19 +145,15 @@ impl InputInjector {
     /// `Command::arg()` only — no shell interpolation. Callers MUST sanitize/cap the text
     /// (strip control chars/newlines, bound length) before calling. Returns `Ok(false)` on
     /// a missing target or tmux soft failure, `Err` on a hard failure.
-    pub fn inject_literal(&self, text: &str) -> Result<bool> {
-        let target = match &self.tmux_target {
-            Some(t) => t,
-            None => return Ok(false),
-        };
-
-        if let Err(reason) = self.validate_target() {
+    pub fn inject_literal(&self, target: &str, socket: Option<&str>, text: &str) -> Result<bool> {
+        if let Err(reason) = Self::validate_target(target, socket) {
             tracing::warn!(%reason, "Target validation failed (inject_literal)");
             return Ok(false);
         }
+        let socket = Self::sanitized_socket(socket);
 
         let mut send_cmd = Command::new("tmux");
-        for arg in self.socket_args() {
+        for arg in Self::socket_args(&socket) {
             send_cmd.arg(arg);
         }
         send_cmd
@@ -185,12 +178,7 @@ impl InputInjector {
 
     /// Send a special key (from whitelist only).
     /// BUG-004 fix: includes socket flag for correct tmux server targeting.
-    pub fn send_key(&self, key: &str) -> Result<bool> {
-        let target = match &self.tmux_target {
-            Some(t) => t,
-            None => return Ok(false),
-        };
-
+    pub fn send_key(&self, target: &str, socket: Option<&str>, key: &str) -> Result<bool> {
         let tmux_key = match key {
             "Enter" => "Enter",
             "Escape" => "Escape",
@@ -207,8 +195,9 @@ impl InputInjector {
             return Ok(false);
         }
 
+        let socket = Self::sanitized_socket(socket);
         let mut cmd = Command::new("tmux");
-        for arg in self.socket_args() {
+        for arg in Self::socket_args(&socket) {
             cmd.arg(arg);
         }
         cmd.arg("send-keys").arg("-t").arg(target).arg(tmux_key);
@@ -233,11 +222,10 @@ impl InputInjector {
     /// visible text, or `None` if no target is set / capture fails. Used by the submit
     /// flow's readiness detection (poll until Claude's multi-select / review screen has
     /// rendered) instead of blind sleeps.
-    pub fn capture_pane(&self) -> Option<String> {
-        let target = self.tmux_target.as_deref()?;
-
+    pub fn capture_pane(&self, target: &str, socket: Option<&str>) -> Option<String> {
+        let socket = Self::sanitized_socket(socket);
         let mut cmd = Command::new("tmux");
-        for arg in self.socket_args() {
+        for arg in Self::socket_args(&socket) {
             cmd.arg(arg);
         }
         cmd.arg("capture-pane").arg("-t").arg(target).arg("-p");
@@ -262,20 +250,21 @@ impl InputInjector {
 
     /// Send a slash command (like /clear).
     /// Validates against character whitelist, sends with -l flag.
-    pub fn send_slash_command(&self, command: &str) -> Result<bool> {
-        let target = match &self.tmux_target {
-            Some(t) => t,
-            None => return Ok(false),
-        };
-
+    pub fn send_slash_command(
+        &self,
+        target: &str,
+        socket: Option<&str>,
+        command: &str,
+    ) -> Result<bool> {
         if !is_valid_slash_command(command) {
             tracing::warn!(%command, "Slash command rejected: contains unsafe characters");
             return Ok(false);
         }
 
+        let socket = Self::sanitized_socket(socket);
         // Send command text with -l (literal mode)
         let mut cmd = Command::new("tmux");
-        for arg in self.socket_args() {
+        for arg in Self::socket_args(&socket) {
             cmd.arg(arg);
         }
         cmd.arg("send-keys")
@@ -291,7 +280,7 @@ impl InputInjector {
 
         // Send Enter
         let mut enter_cmd = Command::new("tmux");
-        for arg in self.socket_args() {
+        for arg in Self::socket_args(&socket) {
             enter_cmd.arg(arg);
         }
         enter_cmd
@@ -383,88 +372,13 @@ impl InputInjector {
         })
     }
 
-    /// Find a tmux session running Claude Code (fallback when $TMUX not set)
-    pub fn find_claude_code_session() -> Option<String> {
-        // Search pane commands
-        let output = Command::new("tmux")
-            .args([
-                "list-panes",
-                "-a",
-                "-F",
-                "#{session_name}:#{pane_current_command}",
-            ])
-            .output()
-            .ok()?;
-
-        if output.status.success() {
-            let stdout = String::from_utf8_lossy(&output.stdout);
-            for line in stdout.lines() {
-                if let Some((session, command)) = line.split_once(':') {
-                    // "node" match removed — was legacy from when ctm was a Node.js process
-                    if command.contains("claude") {
-                        return Some(session.to_string());
-                    }
-                }
-            }
-        }
-
-        // Fallback: session names
-        let output = Command::new("tmux")
-            .args(["list-sessions", "-F", "#{session_name}"])
-            .output()
-            .ok()?;
-
-        if output.status.success() {
-            let stdout = String::from_utf8_lossy(&output.stdout);
-            for line in stdout.lines() {
-                let lower = line.to_lowercase();
-                if lower.contains("claude") || lower.contains("code") {
-                    return Some(line.to_string());
-                }
-            }
-        }
-
-        None
-    }
-}
-
-/// L3.4: Get the injection method name.
-impl InputInjector {
-    /// Returns the injection method: "tmux" if a target is configured, "none" otherwise.
-    #[allow(dead_code)] // Library API
-    pub fn get_method(&self) -> &str {
-        if self.tmux_target.is_some() {
-            "tmux"
-        } else {
-            "none"
-        }
-    }
-
-    /// Returns the configured tmux session target, if any.
-    #[allow(dead_code)] // Library API
-    pub fn get_tmux_session(&self) -> Option<&str> {
-        self.tmux_target.as_deref()
-    }
-
-    /// Returns the configured tmux socket path, if any.
-    #[allow(dead_code)] // Library API
-    pub fn get_tmux_socket(&self) -> Option<&str> {
-        self.tmux_socket.as_deref()
-    }
-}
-
-/// L3.5: Factory function that creates a fully-configured InputInjector.
-///
-/// Detects the current tmux session automatically if tmux is available.
-#[allow(dead_code)] // Library API
-pub fn create_injector() -> InputInjector {
-    let mut inj = InputInjector::new();
-    if InputInjector::is_tmux_available() {
-        if let Some(info) = InputInjector::detect_tmux_session() {
-            inj.set_target(&info.target, info.socket.as_deref());
-        }
-    }
-    inj
+    // ROUTING-001: `find_claude_code_session()` was removed. It scanned for the
+    // FIRST tmux pane running a "claude" process and returned only its session
+    // name (caller manufactured `"{name}:0.0"` — pane 0). Using it for per-session
+    // routing bound a session with a missing pane mapping to an unrelated pane 0,
+    // causing cross-session misrouting. There is no safe way to recover a specific
+    // session's pane by guessing; the only trusted source is the Claude hook's
+    // `tmuxTarget` recorded at session_start.
 }
 
 /// L3.6: Escape text for tmux send-keys.
@@ -494,6 +408,7 @@ pub fn get_hostname() -> String {
 
 #[derive(Debug, Clone)]
 pub struct TmuxInfo {
+    #[allow(dead_code)] // Populated by detect_tmux_session; part of the struct's shape
     pub session: String,
     #[allow(dead_code)] // Library API
     pub pane: String,
@@ -515,31 +430,29 @@ mod tests {
     }
 
     #[test]
-    fn test_injector_no_target() {
+    fn test_injector_nonexistent_target() {
+        // A target that does not exist fails validation and injects nothing
+        // (returns Ok(false)) rather than misrouting.
         let injector = InputInjector::new();
-        assert!(!injector.inject("test").unwrap());
+        assert!(!injector
+            .inject("ctm-no-such-session:9.9", None, "test")
+            .unwrap());
     }
 
     #[test]
-    fn test_socket_path_validation() {
-        let mut injector = InputInjector::new();
-
-        // Valid absolute path
-        injector.set_target("session:0.0", Some("/tmp/tmux-1000/default"));
-        assert!(injector.tmux_socket.is_some());
-
-        // Path traversal rejected
-        injector.set_target("session:0.0", Some("/tmp/../etc/evil"));
-        assert!(injector.tmux_socket.is_none());
-
-        // Relative path rejected
-        injector.set_target("session:0.0", Some("relative/path"));
-        assert!(injector.tmux_socket.is_none());
-
-        // Oversized path rejected
+    fn test_socket_path_sanitization() {
+        // Valid absolute path is preserved.
+        assert_eq!(
+            InputInjector::sanitized_socket(Some("/tmp/tmux-1000/default")).as_deref(),
+            Some("/tmp/tmux-1000/default")
+        );
+        // Path traversal rejected -> None (degrades to default server).
+        assert!(InputInjector::sanitized_socket(Some("/tmp/../etc/evil")).is_none());
+        // Relative path rejected.
+        assert!(InputInjector::sanitized_socket(Some("relative/path")).is_none());
+        // Oversized path rejected.
         let long = format!("/{}", "a".repeat(256));
-        injector.set_target("session:0.0", Some(&long));
-        assert!(injector.tmux_socket.is_none());
+        assert!(InputInjector::sanitized_socket(Some(&long)).is_none());
     }
 
     #[test]

--- a/rust-crates/ctm/src/session.rs
+++ b/rust-crates/ctm/src/session.rs
@@ -465,11 +465,19 @@ impl SessionManager {
     }
 
     pub fn get_session_by_thread_id(&self, thread_id: i64) -> Result<Option<Session>> {
+        // ROUTING-001: ORDER BY last_activity DESC makes this DETERMINISTIC when
+        // more than one active session shares a topic. Sub-agent (child) sessions
+        // deliberately reuse the parent's thread_id (ADR-013), so a topic can map
+        // to several active rows. A bare `LIMIT 1` returned whichever row SQLite
+        // happened to surface, which could route a Telegram reply to a stale/idle
+        // session. Picking the most-recently-active row routes input to the
+        // session the user is actually interacting with in that topic.
         let mut stmt = self
             .conn
             .prepare(
                 "SELECT * FROM sessions
                  WHERE thread_id = ?1 AND status = 'active'
+                 ORDER BY last_activity DESC
                  LIMIT 1",
             )
             .map_err(|e| AppError::Database(e.to_string()))?;

--- a/rust-crates/ctm/tests/routing_spike.rs
+++ b/rust-crates/ctm/tests/routing_spike.rs
@@ -1,0 +1,237 @@
+//! MANUAL SPIKE (ROUTING-001): cross-session mis-routing of Telegram->CLI input.
+//!
+//! Field bug: "I type in session-2's topic on Telegram and the text lands in
+//! pane 0 (session-1) instead of pane 1 (session-2)."
+//!
+//! ── Spike #1 (root cause, ALREADY PROVEN against the pre-fix code) ──────────
+//! The pre-fix `InputInjector` stored a mutable `tmux_target`. `handle_telegram_text`
+//! called `set_target()` in one lock acquisition, DROPPED the lock, awaited, then
+//! re-acquired a FRESH lock to `inject()`. Because each Telegram update is
+//! `tokio::spawn`-ed, a concurrent handler for another session could `set_target()`
+//! in the gap, so `inject()` read the wrong pane. The pre-fix spike forced exactly
+//! that interleaving against real tmux panes and observed:
+//!     pane0 (session-1) got: "MSG_FOR_SESSION_2"
+//!     pane1 (session-2) got: ""
+//! i.e. session-2's reply landed in pane 0 — the reported symptom. That racy
+//! `set_target` API has since been REMOVED, so the buggy pattern can no longer be
+//! written (the fix eliminates the primitive, not just a call site).
+//!
+//! ── Spike #2 (fix verification, THIS FILE) ─────────────────────────────────
+//! With the stateless injector (`inject(target, socket, text)` — target passed per
+//! call, no shared mutable state), run the SAME adversarial interleaving that broke
+//! the old code and assert each session's text reaches ITS OWN pane.
+//!
+//! Uses REAL tmux panes (each runs `cat >> <file>`, so injected keystrokes are
+//! observable as file contents). Run with:
+//!     cargo test -p ctm --test routing_spike -- --ignored --nocapture
+
+use ctm::injector::InputInjector;
+use std::process::Command;
+use std::sync::Arc;
+use std::time::Duration;
+use tokio::sync::{Mutex, Notify};
+
+const SOCK: &str = "/tmp/ctm-routing-spike.sock";
+const SESS: &str = "ctmspike";
+const PANE0_OUT: &str = "/tmp/ctm-spike-pane0.txt";
+const PANE1_OUT: &str = "/tmp/ctm-spike-pane1.txt";
+
+fn tmux(args: &[&str]) -> std::process::Output {
+    Command::new("tmux")
+        .args(["-S", SOCK])
+        .args(args)
+        .output()
+        .expect("tmux invocation failed")
+}
+
+fn tmux_available() -> bool {
+    Command::new("tmux")
+        .arg("-V")
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false)
+}
+
+/// Build a 2-pane tmux session. pane 0 ("ctmspike:0.0") = "session-1",
+/// pane 1 ("ctmspike:0.1") = "session-2". Each pane appends stdin to its file.
+fn setup_panes() {
+    let _ = std::fs::remove_file(PANE0_OUT);
+    let _ = std::fs::remove_file(PANE1_OUT);
+    let _ = tmux(&["kill-session", "-t", SESS]);
+    std::thread::sleep(Duration::from_millis(150));
+
+    let out = tmux(&["new-session", "-d", "-s", SESS, "-x", "120", "-y", "40"]);
+    assert!(
+        out.status.success(),
+        "new-session failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+
+    let c0 = format!("cat >> {PANE0_OUT}");
+    tmux(&["send-keys", "-t", "ctmspike:0.0", "-l", &c0]);
+    tmux(&["send-keys", "-t", "ctmspike:0.0", "Enter"]);
+
+    let out = tmux(&["split-window", "-v", "-t", "ctmspike:0"]);
+    assert!(
+        out.status.success(),
+        "split-window failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let c1 = format!("cat >> {PANE1_OUT}");
+    tmux(&["send-keys", "-t", "ctmspike:0.1", "-l", &c1]);
+    tmux(&["send-keys", "-t", "ctmspike:0.1", "Enter"]);
+
+    std::thread::sleep(Duration::from_millis(300));
+}
+
+fn teardown() {
+    let _ = tmux(&["kill-session", "-t", SESS]);
+}
+
+fn read_out(path: &str) -> String {
+    std::fs::read_to_string(path).unwrap_or_default()
+}
+
+/// Models the FIXED `handle_telegram_text` shape: the per-session target is a
+/// LOCAL, resolved before injection; `inject()` takes it explicitly. The shared
+/// `Arc<Mutex<InputInjector>>` only serializes tmux command execution and carries
+/// no routing state, so a concurrent handler cannot clobber this one's target.
+async fn fixed_resolve_then_inject(
+    inj: Arc<Mutex<InputInjector>>,
+    target: &str,
+    text: &str,
+    after_resolve: Arc<Notify>,
+    before_inject: Arc<Notify>,
+) {
+    // "resolve" the per-session target into a local (no shared set_target).
+    let my_target = target.to_string();
+
+    after_resolve.notify_one();
+    before_inject.notified().await; // let the other session's handler run in the gap
+
+    let g = inj.lock().await;
+    let _ = g.inject(&my_target, Some(SOCK), text);
+}
+
+/// Spike #2: under the exact interleaving that misrouted the pre-fix code,
+/// each session's text now reaches its OWN pane.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+#[ignore = "requires tmux; run explicitly with --ignored"]
+async fn spike_fixed_stateless_injector_routes_per_session() {
+    if !tmux_available() {
+        eprintln!("tmux not available — skipping");
+        return;
+    }
+    setup_panes();
+
+    // ONE shared injector, exactly like the daemon.
+    let inj = Arc::new(Mutex::new(InputInjector::new()));
+
+    // session-2's handler: targets pane 1.
+    let s2_after = Arc::new(Notify::new());
+    let s2_before = Arc::new(Notify::new());
+    let inj2 = Arc::clone(&inj);
+    let a = Arc::clone(&s2_after);
+    let b = Arc::clone(&s2_before);
+    let t2 = tokio::spawn(async move {
+        fixed_resolve_then_inject(inj2, "ctmspike:0.1", "MSG_FOR_SESSION_2", a, b).await;
+    });
+
+    // session-1's handler races in AFTER s2 resolved but BEFORE s2 injected —
+    // the precise window that corrupted the shared target in the old design.
+    let inj1 = Arc::clone(&inj);
+    let a2 = Arc::clone(&s2_after);
+    let b2 = Arc::clone(&s2_before);
+    let t1 = tokio::spawn(async move {
+        a2.notified().await;
+        {
+            let g = inj1.lock().await;
+            let _ = g.inject("ctmspike:0.0", Some(SOCK), "MSG_FOR_SESSION_1");
+        }
+        b2.notify_one(); // release s2 to inject — it carries its OWN target now
+    });
+
+    t1.await.unwrap();
+    t2.await.unwrap();
+    tokio::time::sleep(Duration::from_millis(400)).await;
+
+    let pane0 = read_out(PANE0_OUT);
+    let pane1 = read_out(PANE1_OUT);
+    teardown();
+
+    eprintln!("--- FIX SPIKE (ROUTING-001) ---");
+    eprintln!("pane0 (session-1) got: {pane0:?}");
+    eprintln!("pane1 (session-2) got: {pane1:?}");
+
+    // Correct routing: each message reaches its own pane, none leaks to the other.
+    assert!(
+        pane1.contains("MSG_FOR_SESSION_2"),
+        "session-2's text must reach pane 1. pane1={pane1:?}"
+    );
+    assert!(
+        !pane1.contains("MSG_FOR_SESSION_1"),
+        "session-1's text must NOT leak into pane 1. pane1={pane1:?}"
+    );
+    assert!(
+        pane0.contains("MSG_FOR_SESSION_1"),
+        "session-1's text must reach pane 0. pane0={pane0:?}"
+    );
+    assert!(
+        !pane0.contains("MSG_FOR_SESSION_2"),
+        "REGRESSION: session-2's text leaked into pane 0 (the original bug). pane0={pane0:?}"
+    );
+}
+
+/// Stress variant: many concurrent injects to two distinct panes; assert no
+/// cross-contamination in either direction.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+#[ignore = "requires tmux; run explicitly with --ignored"]
+async fn spike_fixed_concurrent_stress_no_crosstalk() {
+    if !tmux_available() {
+        eprintln!("tmux not available — skipping");
+        return;
+    }
+    setup_panes();
+    let inj = Arc::new(Mutex::new(InputInjector::new()));
+
+    let mut handles = Vec::new();
+    for i in 0..20 {
+        let inj = Arc::clone(&inj);
+        handles.push(tokio::spawn(async move {
+            // Even i -> pane 0 / session-1; odd i -> pane 1 / session-2.
+            let (target, msg) = if i % 2 == 0 {
+                ("ctmspike:0.0", format!("S1_{i}"))
+            } else {
+                ("ctmspike:0.1", format!("S2_{i}"))
+            };
+            // Yield to interleave aggressively.
+            tokio::task::yield_now().await;
+            let g = inj.lock().await;
+            let _ = g.inject(target, Some(SOCK), &msg);
+        }));
+    }
+    for h in handles {
+        h.await.unwrap();
+    }
+    tokio::time::sleep(Duration::from_millis(500)).await;
+
+    let pane0 = read_out(PANE0_OUT);
+    let pane1 = read_out(PANE1_OUT);
+    teardown();
+
+    eprintln!("--- STRESS SPIKE (ROUTING-001) ---");
+    eprintln!("pane0: {pane0:?}");
+    eprintln!("pane1: {pane1:?}");
+
+    // Every S1_* must be in pane0 and never in pane1, and vice-versa.
+    for i in (0..20).step_by(2) {
+        let m = format!("S1_{i}");
+        assert!(pane0.contains(&m), "{m} missing from pane0");
+        assert!(!pane1.contains(&m), "{m} leaked into pane1");
+    }
+    for i in (1..20).step_by(2) {
+        let m = format!("S2_{i}");
+        assert!(pane1.contains(&m), "{m} missing from pane1");
+        assert!(!pane0.contains(&m), "{m} leaked into pane0");
+    }
+}


### PR DESCRIPTION
## Problem

A Telegram reply typed in **session-2's topic** could be injected into **pane 0 (session-1)** — your text reached the wrong Claude session. Claude→Telegram mirroring was unaffected (outbound topic mapping is fine); the bug was in the **inbound** `topic → session → pane` routing.

## Root cause (two independent defects)

Confirmed by manual real-tmux spikes **and** an adversarial Codex review.

**H1 — TOCTOU race on a shared, stateful injector (everyday cause).** There was one `InputInjector` holding a *mutable* `tmux_target`. `handle_telegram_text` called `set_target()` under one lock, **dropped the lock**, `.await`ed, then re-acquired a *fresh* lock to `inject()` (reading the shared target). Telegram updates are `tokio::spawn`-ed concurrently (up to 50), so a handler for another session could clobber the target in the gap. The `cc`/interrupt/kill paths re-locked without even re-setting the target.

**H2 — `get_tmux_target` Tier-3 fallback poisoning (deterministic cause).** When a session's pane was missing from cache *and* DB, it called `find_claude_code_session()`, which returned the **first** pane running `claude` as `"{name}:0.0"` (pane 0) and **persisted that guess** — permanently binding the session to pane 0.

## Fix (`ROUTING-001`)

- **`InputInjector` is now stateless** — `inject`/`inject_literal`/`send_key`/`send_slash_command`/`capture_pane`/`validate_target` all take `(target, socket)` explicitly. No `tmux_target` field, no `set_target`. The `Mutex` now serializes tmux *execution* only, so cross-session target bleed is **structurally impossible**. Socket-path validation preserved on every path via `sanitized_socket()`.
- **All call sites pass the per-session target** — text, photo/doc, `/rename`, `/abort`, Ctrl-C, and the ADR-015 AskUserQuestion submit flow (via a new `Pane` struct; the submit flow still holds the lock for its whole duration).
- **`get_tmux_target` fails closed** — Tier 3 removed, `find_claude_code_session()` deleted. A missing mapping warns the user ("tmux not detected") instead of misrouting. Safe because `update_session_tmux` refreshes each session's target on every Claude hook event.
- **Removed the startup default target** that biased every session toward pane 0.

### Hardening (from Codex diff review)
- `get_session_by_thread_id` now `ORDER BY last_activity DESC` — deterministic when a parent and sub-agent share a topic (ADR-013).
- `check_and_update_tmux_target` reconciles a changed **socket** even when the target string is unchanged.

## Verification (not just "tests green")

`rust-crates/ctm/tests/routing_spike.rs` drives **real tmux panes**:
- **Spike #1** (pre-fix) reproduced the misroute: session-2's message landed in pane 0.
- **Spike #2** (this fix) under the same adversarial interleaving routes each session's text to its own pane; a 20-way concurrent stress spike shows **zero crosstalk**.

All 164 unit/integration tests pass; clippy clean on changed files.

## Notes
- Fix-only branch (cherry-picked off `master`); excludes unrelated talk-docs work.
- 🤖 Generated with [Claude Code](https://claude.com/claude-code)