### PR TITLE
ci(release): set -o pipefail so npm publish failures aren't masked

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -185,6 +185,11 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
+          # pipefail so `npm publish ... | tee` reports npm's exit status, not tee's.
+          # Without it, a failed publish (e.g. EOTP/auth) is masked as success and only
+          # surfaces ~150s later as a misleading "packages not available on registry"
+          # timeout; this also makes the EPUBLISHCONFLICT skip-branch actually reachable.
+          set -o pipefail
           # Publish platform packages first
           for pkg in ctm-linux-x64 ctm-linux-arm64 ctm-darwin-arm64 ctm-darwin-x64; do
             tgz=$(find artifacts/$pkg -name "*.tgz" | head -1)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -192,7 +192,9 @@ jobs:
           set -o pipefail
           # Publish platform packages first
           for pkg in ctm-linux-x64 ctm-linux-arm64 ctm-darwin-arm64 ctm-darwin-x64; do
-            tgz=$(find artifacts/$pkg -name "*.tgz" | head -1)
+            # -print -quit (not `| head -1`): emits the first match and stops with no
+            # pipe, so it can't SIGPIPE-fail (exit 141) under the set -o pipefail above.
+            tgz=$(find artifacts/$pkg -name "*.tgz" -print -quit)
             if [ -n "$tgz" ]; then
               echo "Publishing $pkg..."
               if ! npm publish "$tgz" --access public --provenance 2>&1 | tee /tmp/npm-publish-$pkg.log; then


### PR DESCRIPTION
## Problem
The `Publish platform packages to npm` step uses:
```bash
if ! npm publish "$tgz" --access public --provenance 2>&1 | tee /tmp/npm-publish-$pkg.log; then
```
A pipeline's exit status is the **last** command's (`tee`, ~always 0), so a failed `npm publish` is read as success. During the v0.2.23 release this masked an `npm error code EOTP` (token required an OTP) — the script skipped its error branch and instead failed ~150s later in the registry-propagation wait with a misleading `"Platform packages not available on npm registry"`. The `EPUBLISHCONFLICT` skip-branch was also dead code for the same reason.

## Fix
Add `set -o pipefail` at the top of the step's `run:` block so the pipeline returns `npm publish`'s exit status. Real failures now fail fast with the true error, and the already-published skip-branch becomes reachable on re-runs.

Failure-reporting only — no change to the happy path. Does not affect the already-shipped v0.2.23.

🤖 Generated with [Claude Code](https://claude.com/claude-code)